### PR TITLE
feat!: add Vaadin 25 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ anchorNav.addSection(new Span("Section 2"));
 - Version 1.x.x -> Vaadin 14+
 - Version 2.x.x -> Vaadin 23+
 - Version 3.x.x -> Vaadin 24.5.x (improved accessibility)
+- Version 4.x.x -> Vaadin 25
 
 ## Development instructions
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,19 +5,18 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>anchor-nav</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <name>Anchor Nav for Flow</name>
     <description>Integration of vcf-anchor-nav for Vaadin platform</description>
 
     <properties>
-        <vaadin.version>24.5.0</vaadin.version>
-        <flow.version>9.0.21</flow.version>
+        <vaadin.version>25.0.2</vaadin.version>
 
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jetty.version>11.0.20</jetty.version>
+        <jetty.version>11.0.26</jetty.version>
     </properties>
     <organization>
         <name>Vaadin Component Factory</name>
@@ -98,6 +97,13 @@
             <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev</artifactId>
+            <optional>true</optional>
+        </dependency>
+        
     </dependencies>
 
     <build>
@@ -259,7 +265,7 @@
                         <artifactId>jetty-maven-plugin</artifactId>
                         <version>${jetty.version}</version>
                         <configuration>
-                            <scanIntervalSeconds>0</scanIntervalSeconds>
+                            <scan>0</scan>
                             <supportedPackagings>
                                 <supportedPackaging>jar</supportedPackaging>
                             </supportedPackagings>

--- a/src/main/java/com/vaadin/componentfactory/AnchorNav.java
+++ b/src/main/java/com/vaadin/componentfactory/AnchorNav.java
@@ -4,7 +4,7 @@ package com.vaadin.componentfactory;
  * #%L
  * Anchor Nav for Flow
  * %%
- * Copyright (C) 2020 - 2024 Vaadin Ltd
+ * Copyright (C) 2020 - 2026 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
  * @author Vaadin Ltd
  */
 @Tag("vcf-anchor-nav")
-@NpmPackage(value = "@vaadin-component-factory/vcf-anchor-nav", version = "3.0.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-anchor-nav", version = "4.0.0")
 @JsModule("@vaadin-component-factory/vcf-anchor-nav")
 @SuppressWarnings("serial")
 public class AnchorNav extends HtmlContainer implements HasTheme {

--- a/src/main/java/com/vaadin/componentfactory/AnchorNavSection.java
+++ b/src/main/java/com/vaadin/componentfactory/AnchorNavSection.java
@@ -4,7 +4,7 @@ package com.vaadin.componentfactory;
  * #%L
  * Anchor Nav for Flow
  * %%
- * Copyright (C) 2020 - 2024 Vaadin Ltd
+ * Copyright (C) 2020 - 2026 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/vaadin/componentfactory/AnchorNavVariant.java
+++ b/src/main/java/com/vaadin/componentfactory/AnchorNavVariant.java
@@ -4,7 +4,7 @@ package com.vaadin.componentfactory;
  * #%L
  * Anchor Nav for Flow
  * %%
- * Copyright (C) 2020 - 2024 Vaadin Ltd
+ * Copyright (C) 2020 - 2026 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/vaadin/componentfactory/util/SlotHelper.java
+++ b/src/main/java/com/vaadin/componentfactory/util/SlotHelper.java
@@ -4,7 +4,7 @@ package com.vaadin.componentfactory.util;
  * #%L
  * Anchor Nav for Flow
  * %%
- * Copyright (C) 2020 - 2024 Vaadin Ltd
+ * Copyright (C) 2020 - 2026 Vaadin Ltd
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/vaadin/componentfactory/AppShellConfiguratorImpl.java
+++ b/src/test/java/com/vaadin/componentfactory/AppShellConfiguratorImpl.java
@@ -1,0 +1,10 @@
+package com.vaadin.componentfactory;
+
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.theme.lumo.Lumo;
+
+@StyleSheet(Lumo.STYLESHEET)
+public class AppShellConfiguratorImpl implements AppShellConfigurator {
+
+}


### PR DESCRIPTION
**This PR depends on the release of vcf-anchor-nav web component version 4.0.0 release. See https://github.com/vaadin-component-factory/vcf-anchor-nav/pull/16**

This PR includes necessary updates to support Vaadin 25.0. Changes:

- Web component dependency updated to 4.0.0, which now uses Lit instead of Polymer.
- Vaadin version updated to 25.0.2.
- Component version updated to 4.0.0-SNAPSHOT as it is a breaking change to support a new Vaadin version.
- Demo configuration, license headers & readme update. 